### PR TITLE
Make demo.html mobile friendly

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Demo of KV Web3 tools</title>
 </head>
 <body>


### PR DESCRIPTION
I have simply added the 'viewport' meta-tag so that the demo looks decent on mobile phones without having to zoom in and out. WalletConnect's popup fits nicely too. Desktop layout is not affected.
While at it, I've also added the missing doctype declaration so the html is valid (probably had no practical consequences)